### PR TITLE
Update schema URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Die Schnittstelle ermöglicht das automatisierte Anlegen von Vorgängen in **Kredit**Smart.
 
-Unter https://github.com/hypoport/kreditsmart-kex-vorgang-api-schema liegt das zugehörige JSON-Schema, das zur Codegenerierung genutzt werden kann.
+Unter https://github.com/europace/kex-vorgang-api-schema liegt das zugehörige JSON-Schema, das zur Codegenerierung genutzt werden kann.
 
 # Table of Contents
 


### PR DESCRIPTION
Da das Schema umgezogen ist muss hier die URL angepasst werden. Die alte URL funktioniert aber noch, daher ist dies nicht kritisch