### PR TITLE
Remove `rueckkaufswert` and `angesparterBetrag`

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,6 @@ In addition there is the value "SONSTIGE" ("other")
 #### Bausparvertrag
 
     {
-        "angesparterBetrag": BigDecimal,
         "gehoertZuAntragsteller": Antragstellerzuordnung,
         "sparbeitragMonatlich": BigDecimal
     }
@@ -542,8 +541,7 @@ In addition there is the value "SONSTIGE" ("other")
 
     {
         "gehoertZuAntragsteller": Antragstellerzuordnung,
-        "praemieMonatlich": BigDecimal,
-        "rueckkaufswert": BigDecimal,
+        "praemieMonatlich": BigDecimal
     }
     
 #### Sonstiger Vermögenswert


### PR DESCRIPTION
The properties `rueckkaufswert` and `angesparterBetrag` are no longer in use and therefore will be removed from the API.

If a user is still sending the properties, the Vorgang will still be imported with a hint in the messages property that these properties are unknown.